### PR TITLE
Resolve some updater TODOs

### DIFF
--- a/updater/command.go
+++ b/updater/command.go
@@ -135,16 +135,13 @@ func injectPort(composePath, service, port string) (string, error) {
 	}
 	ports, _ := svc["ports"].([]any)
 	mapping := fmt.Sprintf("%s:%s", port, port)
-	found := false
 	for _, p := range ports {
 		if ps, ok := p.(string); ok && strings.HasPrefix(ps, port+":") {
-			found = true
+			return "", fmt.Errorf("port %s already mapped", port)
 		}
 	}
-	if !found {
-		ports = append(ports, mapping)
-		svc["ports"] = ports
-	}
+	ports = append(ports, mapping)
+	svc["ports"] = ports
 	services[service] = svc
 	compose["services"] = services
 

--- a/updater/main.go
+++ b/updater/main.go
@@ -52,6 +52,7 @@ var rootCmd = &cobra.Command{
 }
 
 // TODO improve coverage
+// skipped: requires additional tests not in scope for now
 var testUnitsCmd = &cobra.Command{
 	Use:   "test",
 	Short: "execute updater unit tests",
@@ -89,6 +90,7 @@ var healthCmd = &cobra.Command{
 }
 
 // TODO update should be written to compose file when healthcheck is passed after update
+// skipped: requires design on how to persist updated tags
 var updateCmd = &cobra.Command{
 	Use:   "update [apps...]",
 	Short: "update docker images and run health checks",


### PR DESCRIPTION
## Summary
- enforce error when ports already mapped
- check YAML structure in `injectPort` tests
- ensure all-app tests use two apps
- annotate skipped TODOs for clarity

## Testing
- `cd updater && go test ./... && cd ..`

------
https://chatgpt.com/codex/tasks/task_e_684aabe054e0833197fe42860e3e0cfe