### PR TITLE
Address TODOs with improved health checks

### DIFF
--- a/updater/main.go
+++ b/updater/main.go
@@ -75,13 +75,15 @@ var healthCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		tr.PrintTaskDescription("running health checks")
 		mgr := buildManager()
-		healthy, err := mgr.HealthCheck(args)
+		results, err := mgr.HealthCheck(args)
 		if err != nil {
 			return err
 		}
 		fmt.Println("summary: all services healthy")
-		for _, name := range healthy {
-			fmt.Printf("- %s\n", name)
+		for _, r := range results {
+			if r.Success {
+				fmt.Printf("- %s\n", r.App)
+			}
 		}
 		return nil
 	},


### PR DESCRIPTION
## Summary
- extend health check logic to report per-app results
- adapt updater to use new health check information
- show only healthy apps in CLI output
- add test covering partial update failures

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ab1b694048331a5ee10b354682a3c